### PR TITLE
Show rbenv ruby-version even when is global

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -7,8 +7,6 @@ function _prompt_rubies -a sep_color -a ruby_color -d 'Display current Ruby (rvm
     set ruby_version (rvm-prompt i v g)
   else if type rbenv >/dev/null 2>&1
     set ruby_version (rbenv version-name)
-    # Don't show global ruby version...
-    [ "$ruby_version" = (rbenv global) ]; and return
   end
   [ -z "$ruby_version" ]; and return
 


### PR DESCRIPTION
If my global version of ruby is the same as the current one
while using rbenv it is not show.

I'd like rbenv ruby-version to have the same behaviour as `rvm`. I use `rvm` at work and `rbenv` at home. I missed this feature a lot. :D
